### PR TITLE
Update dply.sh

### DIFF
--- a/dply.sh
+++ b/dply.sh
@@ -14,7 +14,7 @@ apt-get update
 apt-get -y upgrade
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
-sudo apt-get install -y build-essential
+sudo apt-get install -y build-essential python-minimal
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update && sudo apt-get install yarn


### PR DESCRIPTION
need python 2 for some reason 

Building: /usr/bin/nodejs /usr/lib/node_modules/@angular/cli/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [ '/usr/bin/nodejs',
gyp verb cli   '/usr/lib/node_modules/@angular/cli/node_modules/node-gyp/bin/node-gyp.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library=' ]
gyp info using node-gyp@3.6.2
gyp info using node@8.1.2 | linux | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing "build" directory
gyp verb command configure []
gyp verb check python checking for Python executable "python2" in the PATH
gyp verb `which` failed Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed  python2 { Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21) code: 'ENOENT' }
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` failed Error: not found: python
gyp verb `which` failed     at getNotFoundError (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed  python { Error: not found: python
gyp verb `which` failed     at getNotFoundError (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21) code: 'ENOENT' }
gyp ERR! configure error 
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/usr/lib/node_modules/@angular/cli/node_modules/node-gyp/lib/configure.js:483:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/usr/lib/node_modules/@angular/cli/node_modules/node-gyp/lib/configure.js:397:16)
gyp ERR! stack     at F (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/usr/lib/node_modules/@angular/cli/node_modules/which/which.js:80:29)
gyp ERR! stack     at /usr/lib/node_modules/@angular/cli/node_modules/which/which.js:89:16
gyp ERR! stack     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /usr/lib/node_modules/@angular/cli/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:152:21)
gyp ERR! System Linux 4.4.0-79-generic
gyp ERR! command "/usr/bin/nodejs" "/usr/lib/node_modules/@angular/cli/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /usr/lib/node_modules/@angular/cli/node_modules/node-sass
gyp ERR! node -v v8.1.2
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok 
Build failed with error code: 1
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: node-sass@4.5.3 (node_modules/@angular/cli/node_modules/node-sass):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: node-sass@4.5.3 postinstall: `node scripts/build.js`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1