### PR TITLE
Create docker.sh

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update
+sudo apt-get install apt-transport-https ca-certificates curl software-properties-common -y
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
+sudo apt-get update
+sudo apt-get install docker-ce -y
+sudo docker run hello-world


### PR DESCRIPTION
tested in zesty

```
$ sudo sh docker.sh 
Hit:1 http://us.archive.ubuntu.com/ubuntu zesty InRelease
Get:2 http://security.ubuntu.com/ubuntu zesty-security InRelease [89.2 kB]
Get:3 http://us.archive.ubuntu.com/ubuntu zesty-updates InRelease [89.2 kB]     
Get:4 http://us.archive.ubuntu.com/ubuntu zesty-backports InRelease [89.2 kB]   
Hit:5 http://packages.microsoft.com/repos/vscode stable InRelease               
Hit:6 https://deb.nodesource.com/node_8.x zesty InRelease                       
Hit:7 https://download.docker.com/linux/ubuntu zesty InRelease
Hit:8 https://dl.yarnpkg.com/debian stable InRelease
Fetched 268 kB in 4s (59.5 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
apt-transport-https is already the newest version (1.4).
ca-certificates is already the newest version (20161130).
software-properties-common is already the newest version (0.96.24.13).
curl is already the newest version (7.52.1-4ubuntu1.1).
The following packages were automatically installed and are no longer required:
  linux-headers-4.10.0-22 linux-headers-4.10.0-22-generic linux-image-4.10.0-22-generic linux-image-extra-4.10.0-22-generic
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
OK
Hit:1 http://us.archive.ubuntu.com/ubuntu zesty InRelease
Get:2 http://us.archive.ubuntu.com/ubuntu zesty-updates InRelease [89.2 kB]
Get:3 http://security.ubuntu.com/ubuntu zesty-security InRelease [89.2 kB]
Hit:4 http://packages.microsoft.com/repos/vscode stable InRelease   
Get:5 http://us.archive.ubuntu.com/ubuntu zesty-backports InRelease [89.2 kB]                   
Hit:6 https://deb.nodesource.com/node_8.x zesty InRelease      
Hit:7 https://download.docker.com/linux/ubuntu zesty InRelease
Hit:8 https://dl.yarnpkg.com/debian stable InRelease
Fetched 268 kB in 4s (64.7 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
docker-ce is already the newest version (17.06.0~ce-0~ubuntu).
The following packages were automatically installed and are no longer required:
  linux-headers-4.10.0-22 linux-headers-4.10.0-22-generic linux-image-4.10.0-22-generic linux-image-extra-4.10.0-22-generic
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.

Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://cloud.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/engine/userguide/
```